### PR TITLE
Move images to save directory feature

### DIFF
--- a/imagepaste/clipboard/darwin/darwin.py
+++ b/imagepaste/clipboard/darwin/darwin.py
@@ -40,7 +40,7 @@ class DarwinClipboard(Clipboard):
         urls = pb.get_file_urls()
         if urls is not None:
             filepaths = list(urls)
-            images = [Image(filepath) for filepath in filepaths]
+            images = [Image(filepath, is_pasted=True) for filepath in filepaths]
             return cls(Report(6, f"Pasted {len(images)} image files: {images}"), images)
 
         # Save an image if it is in the clipboard
@@ -48,7 +48,6 @@ class DarwinClipboard(Clipboard):
         if contents is not None:
             filename = cls.get_timestamp_filename()
             filepath = join(save_directory, filename)
-            image = Image(filepath, filename)
             commands = [
                 "set pastedImage to "
                 f'(open for access POSIX file "{filepath}" with write permission)',
@@ -59,7 +58,9 @@ class DarwinClipboard(Clipboard):
             ]
             process = Process.execute(cls.get_osascript_args(commands))
             if not isfile(filepath):
+                image = Image(filepath, filename)
                 return cls(Report(3, f"Cannot save image: {image} ({process.stderr})"))
+            image = Image(filepath, filename, is_pasted=True)
             if process.stderr:
                 report = Report(6, f"Saved 1 image: {image} (WARN: {process.stderr})")
                 return cls(report, [image])

--- a/imagepaste/clipboard/darwin/darwin.py
+++ b/imagepaste/clipboard/darwin/darwin.py
@@ -40,7 +40,7 @@ class DarwinClipboard(Clipboard):
         urls = pb.get_file_urls()
         if urls is not None:
             filepaths = list(urls)
-            images = [Image(filepath, is_pasted=True) for filepath in filepaths]
+            images = [Image(filepath, pasted=True) for filepath in filepaths]
             return cls(Report(6, f"Pasted {len(images)} image files: {images}"), images)
 
         # Save an image if it is in the clipboard
@@ -60,7 +60,7 @@ class DarwinClipboard(Clipboard):
             if not isfile(filepath):
                 image = Image(filepath)
                 return cls(Report(3, f"Cannot save image: {image} ({process.stderr})"))
-            image = Image(filepath, is_pasted=True)
+            image = Image(filepath, pasted=True)
             if process.stderr:
                 report = Report(6, f"Saved 1 image: {image} (WARN: {process.stderr})")
                 return cls(report, [image])

--- a/imagepaste/clipboard/darwin/darwin.py
+++ b/imagepaste/clipboard/darwin/darwin.py
@@ -58,9 +58,9 @@ class DarwinClipboard(Clipboard):
             ]
             process = Process.execute(cls.get_osascript_args(commands))
             if not isfile(filepath):
-                image = Image(filepath, filename)
+                image = Image(filepath)
                 return cls(Report(3, f"Cannot save image: {image} ({process.stderr})"))
-            image = Image(filepath, filename, is_pasted=True)
+            image = Image(filepath, is_pasted=True)
             if process.stderr:
                 report = Report(6, f"Saved 1 image: {image} (WARN: {process.stderr})")
                 return cls(report, [image])

--- a/imagepaste/clipboard/linux/linux.py
+++ b/imagepaste/clipboard/linux/linux.py
@@ -52,12 +52,13 @@ class LinuxClipboard(Clipboard):
         if XclipTarget.IMAGE.value in process.stdout:
             filename = cls.get_timestamp_filename()
             filepath = join(save_directory, filename)
-            image = Image(filepath, filename)
             process = Process.execute(
                 cls.get_xclip_args(XclipTarget.IMAGE.value), outpath=filepath
             )
             if process.stderr:
+                image = Image(filepath, filename)
                 return cls(Report(3, f"Cannot save image: {image} ({process.stderr})"))
+            image = Image(filepath, filename, is_pasted=True)
             return cls(Report(6, f"Saved and pasted 1 image: {image}"), [image])
 
         # If copying from files, just send their paths
@@ -65,7 +66,7 @@ class LinuxClipboard(Clipboard):
             uris = Process.execute(cls.get_xclip_args(XclipTarget.URI.value)).stdout
             filepaths = [url2pathname((urlparse(uri).path)) for uri in uris]
             # TODO: Check if files are images
-            images = [Image(filepath) for filepath in filepaths]
+            images = [Image(filepath, is_pasted=True) for filepath in filepaths]
             return cls(Report(6, f"Pasted {len(images)} image files: {images}"), images)
         return cls(Report(2))
 

--- a/imagepaste/clipboard/linux/linux.py
+++ b/imagepaste/clipboard/linux/linux.py
@@ -56,9 +56,9 @@ class LinuxClipboard(Clipboard):
                 cls.get_xclip_args(XclipTarget.IMAGE.value), outpath=filepath
             )
             if process.stderr:
-                image = Image(filepath, filename)
+                image = Image(filepath)
                 return cls(Report(3, f"Cannot save image: {image} ({process.stderr})"))
-            image = Image(filepath, filename, is_pasted=True)
+            image = Image(filepath, is_pasted=True)
             return cls(Report(6, f"Saved and pasted 1 image: {image}"), [image])
 
         # If copying from files, just send their paths

--- a/imagepaste/clipboard/linux/linux.py
+++ b/imagepaste/clipboard/linux/linux.py
@@ -58,7 +58,7 @@ class LinuxClipboard(Clipboard):
             if process.stderr:
                 image = Image(filepath)
                 return cls(Report(3, f"Cannot save image: {image} ({process.stderr})"))
-            image = Image(filepath, is_pasted=True)
+            image = Image(filepath, pasted=True)
             return cls(Report(6, f"Saved and pasted 1 image: {image}"), [image])
 
         # If copying from files, just send their paths
@@ -66,7 +66,7 @@ class LinuxClipboard(Clipboard):
             uris = Process.execute(cls.get_xclip_args(XclipTarget.URI.value)).stdout
             filepaths = [url2pathname((urlparse(uri).path)) for uri in uris]
             # TODO: Check if files are images
-            images = [Image(filepath, is_pasted=True) for filepath in filepaths]
+            images = [Image(filepath, pasted=True) for filepath in filepaths]
             return cls(Report(6, f"Pasted {len(images)} image files: {images}"), images)
         return cls(Report(2))
 

--- a/imagepaste/clipboard/windows/windows.py
+++ b/imagepaste/clipboard/windows/windows.py
@@ -41,10 +41,10 @@ class WindowsClipboard(Clipboard):
         )
         process = Process.execute(cls.get_powershell_args(image_script), split=False)
         if process.stderr:
-            image = Image(filepath, filename)
+            image = Image(filepath)
             return cls(Report(3, f"Cannot save image: {image} ({process.stderr})"))
         if process.stdout == "0":
-            image = Image(filepath, filename, is_pasted=True)
+            image = Image(filepath, is_pasted=True)
             return cls(Report(6, f"Saved and pasted 1 image: {image}"), [image])
 
         file_script = (

--- a/imagepaste/clipboard/windows/windows.py
+++ b/imagepaste/clipboard/windows/windows.py
@@ -44,7 +44,7 @@ class WindowsClipboard(Clipboard):
             image = Image(filepath)
             return cls(Report(3, f"Cannot save image: {image} ({process.stderr})"))
         if process.stdout == "0":
-            image = Image(filepath, is_pasted=True)
+            image = Image(filepath, pasted=True)
             return cls(Report(6, f"Saved and pasted 1 image: {image}"), [image])
 
         file_script = (

--- a/imagepaste/clipboard/windows/windows.py
+++ b/imagepaste/clipboard/windows/windows.py
@@ -34,7 +34,6 @@ class WindowsClipboard(Clipboard):
 
         filename = cls.get_timestamp_filename()
         filepath = join(save_directory, filename)
-        image = Image(filepath, filename)
 
         image_script = (
             "$image = Get-Clipboard -Format Image\n"
@@ -42,8 +41,10 @@ class WindowsClipboard(Clipboard):
         )
         process = Process.execute(cls.get_powershell_args(image_script), split=False)
         if process.stderr:
+            image = Image(filepath, filename)
             return cls(Report(3, f"Cannot save image: {image} ({process.stderr})"))
         if process.stdout == "0":
+            image = Image(filepath, filename, is_pasted=True)
             return cls(Report(6, f"Saved and pasted 1 image: {image}"), [image])
 
         file_script = (

--- a/imagepaste/helper.py
+++ b/imagepaste/helper.py
@@ -10,8 +10,6 @@ def get_addon_preferences() -> bpy.types.AddonPreferences:
     Returns:
         bpy.types.AddonPreferences: The addon preferences.
     """
-    import bpy
-
     return bpy.context.preferences.addons[ADDON_NAME].preferences
 
 
@@ -28,14 +26,22 @@ def get_save_directory() -> str:
 
     preferences = get_addon_preferences()
 
-    if bpy.data.filepath and not preferences.is_force_use_another_directory:
-        directory_path = dirname(bpy.data.filepath)
-        if preferences.is_use_subdirectory and preferences.subdirectory_name:
-            subdirectory_path = join(directory_path, preferences.subdirectory_name)
-            if not exists(subdirectory_path):
-                makedirs(subdirectory_path)
-            return subdirectory_path
-        return directory_path
-    if preferences.is_use_another_directory and preferences.another_directory:
+    if not bpy.data.filepath:
+        if preferences.is_use_another_directory and preferences.another_directory:
+            return preferences.another_directory
+        return bpy.app.tempdir
+
+    if (
+        preferences.is_use_another_directory
+        and preferences.is_force_use_another_directory
+        and preferences.another_directory
+    ):
         return preferences.another_directory
-    return bpy.app.tempdir
+
+    directory_path = dirname(bpy.data.filepath)
+    if not preferences.is_use_subdirectory or not preferences.subdirectory_name:
+        return directory_path
+    subdirectory_path = join(directory_path, preferences.subdirectory_name)
+    if not exists(subdirectory_path):
+        makedirs(subdirectory_path)
+    return subdirectory_path

--- a/imagepaste/image.py
+++ b/imagepaste/image.py
@@ -1,7 +1,7 @@
 class Image:
     """A class to represent an image file."""
 
-    pasted_image = []
+    filepath_to_image = {}
 
     def __init__(self, filepath: str, filename: str = None) -> None:
         """Constructor for the Image class.
@@ -16,7 +16,7 @@ class Image:
         self.filepath = filepath
         self.filename = filename or basename(filepath)
         self.filebase = dirname(filepath)
-        Image.pasted_image.append(self)
+        Image.filepath_to_image[self.filepath] = self
 
     def __repr__(self) -> str:
         """Return a string representation of the Image class.

--- a/imagepaste/image.py
+++ b/imagepaste/image.py
@@ -3,16 +3,16 @@ class Image:
 
     pasted_images = {}
 
-    def __init__(self, filepath: str, is_pasted: bool = False) -> None:
+    def __init__(self, filepath: str, pasted: bool = False) -> None:
         """Constructor for the Image class.
 
         Args:
             filepath (str): The path to the image file.
             filename (str, optional): The name of the image file.
-            is_pasted (bool, optional): Whether the image is pasted.
+            pasted (bool, optional): Whether the image is pasted.
         """
         self.filepath = filepath
-        if is_pasted:
+        if pasted:
             Image.pasted_images[self.filepath] = self
 
     @property

--- a/imagepaste/image.py
+++ b/imagepaste/image.py
@@ -1,6 +1,8 @@
 class Image:
     """A class to represent an image file."""
 
+    pasted_image = []
+
     def __init__(self, filepath: str, filename: str = None) -> None:
         """Constructor for the Image class.
 
@@ -14,6 +16,7 @@ class Image:
         self.filepath = filepath
         self.filename = filename or basename(filepath)
         self.filebase = dirname(filepath)
+        Image.pasted_image.append(self)
 
     def __repr__(self) -> str:
         """Return a string representation of the Image class.

--- a/imagepaste/image.py
+++ b/imagepaste/image.py
@@ -1,14 +1,17 @@
 class Image:
     """A class to represent an image file."""
 
-    filepath_to_image = {}
+    pasted_images = {}
 
-    def __init__(self, filepath: str, filename: str = None) -> None:
+    def __init__(
+        self, filepath: str, filename: str = None, is_pasted: bool = False
+    ) -> None:
         """Constructor for the Image class.
 
         Args:
             filepath (str): The path to the image file.
             filename (str, optional): The name of the image file.
+            is_pasted (bool, optional): Whether the image is pasted.
         """
         from os.path import basename
         from os.path import dirname
@@ -16,7 +19,8 @@ class Image:
         self.filepath = filepath
         self.filename = filename or basename(filepath)
         self.filebase = dirname(filepath)
-        Image.filepath_to_image[self.filepath] = self
+        if is_pasted:
+            Image.pasted_images[self.filepath] = self
 
     def __repr__(self) -> str:
         """Return a string representation of the Image class.

--- a/imagepaste/image.py
+++ b/imagepaste/image.py
@@ -3,9 +3,7 @@ class Image:
 
     pasted_images = {}
 
-    def __init__(
-        self, filepath: str, filename: str = None, is_pasted: bool = False
-    ) -> None:
+    def __init__(self, filepath: str, is_pasted: bool = False) -> None:
         """Constructor for the Image class.
 
         Args:
@@ -13,14 +11,28 @@ class Image:
             filename (str, optional): The name of the image file.
             is_pasted (bool, optional): Whether the image is pasted.
         """
+        self.filepath = filepath
+        if is_pasted:
+            Image.pasted_images[self.filepath] = self
+
+    @property
+    def filepath(self) -> str:
+        """Get the path to the image file."""
+        return self._filepath
+
+    @filepath.setter
+    def filepath(self, filepath: str) -> None:
+        """Set the path to the image file.
+
+        Args:
+            filepath (str): The path to the image file.
+        """
         from os.path import basename
         from os.path import dirname
 
-        self.filepath = filepath
-        self.filename = filename or basename(filepath)
+        self._filepath = filepath
+        self.filename = basename(filepath)
         self.filebase = dirname(filepath)
-        if is_pasted:
-            Image.pasted_images[self.filepath] = self
 
     def __repr__(self) -> str:
         """Return a string representation of the Image class.

--- a/imagepaste/operators.py
+++ b/imagepaste/operators.py
@@ -219,7 +219,7 @@ class IMAGEPASTE_OT_move_to_saved_directory(bpy.types.Operator):
     def execute(self, _context):
         from .image import Image
 
-        filepath_to_image = Image.filepath_to_image
+        pasted_images = Image.pasted_images
         orphaned_image_filepaths = []
         # Change the paths the images refers to with the new one
         for orphaned_image in self.orphaned_images:
@@ -227,13 +227,13 @@ class IMAGEPASTE_OT_move_to_saved_directory(bpy.types.Operator):
             self.change_image_directory(orphaned_image, self.saved_directory)
             new_filepath = self.get_abspath(orphaned_image.filepath)
             # Also change in the dictionary
-            if old_filepath in filepath_to_image:
-                filepath_to_image[new_filepath] = filepath_to_image.pop(old_filepath)
+            if old_filepath in pasted_images:
+                pasted_images[new_filepath] = pasted_images.pop(old_filepath)
             orphaned_image_filepaths.append(old_filepath)
         # Remove pasted images which are not in `.blend` file (pasted but then undone)
-        for filepath in list(filepath_to_image.keys()):
+        for filepath in list(pasted_images.keys()):
             if filepath in orphaned_image_filepaths:
-                del filepath_to_image[filepath]
+                del pasted_images[filepath]
         return {"FINISHED"}
 
     def invoke(self, context, _event):
@@ -274,7 +274,7 @@ class IMAGEPASTE_OT_move_to_saved_directory(bpy.types.Operator):
         preferences = get_addon_preferences()
         if preferences.image_type_to_move == "no_moving":
             return []
-        filepath_to_image = Image.filepath_to_image
+        pasted_images = Image.pasted_images
         existing_images = bpy.data.images
         orphaned_images = []
         for image in existing_images:
@@ -287,7 +287,7 @@ class IMAGEPASTE_OT_move_to_saved_directory(bpy.types.Operator):
             if preferences.image_type_to_move == "all_images":
                 orphaned_images.append(image)
                 continue
-            if filepath in filepath_to_image:
+            if filepath in pasted_images:
                 orphaned_images.append(image)
         return orphaned_images
 

--- a/imagepaste/report.py
+++ b/imagepaste/report.py
@@ -1,3 +1,6 @@
+import bpy
+
+
 class Report:
     """A class to hold information about a report."""
 
@@ -8,6 +11,7 @@ class Report:
         4: ["ERROR", "Unable to copy image"],
         5: ["INFO", "Copied image"],
         6: ["INFO", "Pasted image"],
+        7: ["INFO", "Moved images"],
     }
 
     def __init__(self, code: int, verbose: str = None) -> None:
@@ -23,18 +27,33 @@ class Report:
         self.message = Report.REPORT_TABLE[self.code][1]
         self.verbose = verbose or self.message
 
-    def log(self) -> None:
-        """Log the report to the console."""
+    def log(self, operator: bpy.types.Operator) -> None:
+        """Log the report to the Blender UI and console.
+
+        Args:
+            operator (bpy.types.Operator): The operator calling the report. If the
+                method is called from a Blender operator method, it is usually `self`.
+        """
+        operator.report({self.type}, self.message)
+        Report.console_log(self.verbose)
+
+    @staticmethod
+    def console_log(message: str) -> None:
+        """Log the message to the console.
+
+        Args:
+            message (str): The message to be printed to the console.
+        """
         from .helper import get_addon_preferences
 
         preferences = get_addon_preferences()
         if not preferences.is_disable_debug:
-            print(f"ImagePaste: {self.verbose}")
+            print(f"ImagePaste: {message}")
 
     def __repr__(self) -> str:
-        """Return the string representation of the report
+        """Return the string representation of the report.
 
         Returns:
-            str: The string representation of the report
+            str: The string representation of the report.
         """
         return f"({self.code}:{self.type})<{self.message}>"


### PR DESCRIPTION
## Proposed changes

This new feature will move (actually copy) pasted images or all images the users have used in their `.blend` file into the save directory after they save the file, so they won't have to worry about missing files anymore. There's also an option in the add-on preferences for users to choose the type of images to move:
- **Pasted images**: Only images which were pasted using the add-on would be moved to the save directory.
- **All images**: Images existing in the `.blend` file will be moved.
- **No moving**: Don't do anything when saving the file.

## Screenshots/Screencasts

- A new section for choosing the images type to move:
![Shadow card[1]](https://user-images.githubusercontent.com/60842560/127760135-4eb29ff8-c254-4a0c-8b1e-cbafbfc2bac8.png)
- A video demo:

https://user-images.githubusercontent.com/60842560/128070061-1737d38a-b4b9-44b3-a5b3-cba61b640194.mp4