### PR TITLE
Filename customization feature

### DIFF
--- a/imagepaste/clipboard/clipboard.py
+++ b/imagepaste/clipboard/clipboard.py
@@ -56,7 +56,7 @@ class Clipboard(ABC):
         pass
 
     @staticmethod
-    def get_timestamp_filename() -> str:
+    def get_filename() -> str:
         """Get a string representation of the current time in the file name format.
 
         Returns:

--- a/imagepaste/clipboard/clipboard.py
+++ b/imagepaste/clipboard/clipboard.py
@@ -62,43 +62,9 @@ class Clipboard(ABC):
         Returns:
             str: a string representing the current time in the file name format.
         """
-
-        def populate_filename(pattern: str) -> str:
-            """Populate a filename with a pattern.
-
-            Args:
-                pattern (str): a string representing a pattern.
-
-            Returns:
-                str: a string representing a filename.
-            """
-            from time import strftime
-            from ..image import Image
-            from ..helper import ADDON_NAME
-
-            VARIABLES_TABLE = [
-                ("${addonName}", ADDON_NAME),
-                ("${yearLong}", strftime("%Y")),
-                ("${yearShort}", strftime("%y")),
-                ("${monthNumber}", strftime("%m")),
-                ("${monthNameLong}", strftime("%B")),
-                ("${monthNameShort}", strftime("%b")),
-                ("${day}", strftime("%d")),
-                ("${weekdayNumber}", strftime("%w")),
-                ("${weekdayNameLong}", strftime("%A")),
-                ("${weekdayNameShort}", strftime("%a")),
-                ("${hour24}", strftime("%H")),
-                ("${hour12}", strftime("%I")),
-                ("${minute}", strftime("%M")),
-                ("${second}", strftime("%S")),
-                ("${index}", str(len(Image.pasted_images) + 1)),
-            ]
-            for pattern_key, pattern_value in VARIABLES_TABLE:
-                pattern = pattern.replace(pattern_key, pattern_value)
-            return pattern
-
         from time import strftime
         from ..helper import get_addon_preferences
+        from ..helper import populate_filename
         from ..helper import is_valid_filename
 
         preferences = get_addon_preferences()

--- a/imagepaste/clipboard/clipboard.py
+++ b/imagepaste/clipboard/clipboard.py
@@ -102,10 +102,13 @@ class Clipboard(ABC):
         from ..helper import is_valid_filename
 
         preferences = get_addon_preferences()
-        filename = populate_filename(preferences.image_filename_pattern) + ".png"
+        filename = (
+            populate_filename(preferences.image_filename_pattern)
+            + preferences.image_extension
+        )
         if is_valid_filename(filename):
             return filename
-        return strftime("ImagePaste-%y%m%d-%H%M%S.png")
+        return strftime(f"ImagePaste-%y%m%d-%H%M%S{preferences.image_extension}")
 
     def __repr__(self) -> str:
         """Representation of the object.

--- a/imagepaste/clipboard/clipboard.py
+++ b/imagepaste/clipboard/clipboard.py
@@ -62,8 +62,26 @@ class Clipboard(ABC):
         Returns:
             str: a string representing the current time in the file name format.
         """
-        from time import strftime
 
+        def populate_filename(pattern: str) -> str:
+            """Populate a filename with a pattern.
+
+            Args:
+                pattern (str): a string representing a pattern.
+
+            Returns:
+                str: a string representing a filename.
+            """
+            return pattern
+
+        from time import strftime
+        from ..helper import get_addon_preferences
+        from ..helper import is_valid_filename
+
+        preferences = get_addon_preferences()
+        filename = populate_filename(preferences.image_filename_pattern) + ".png"
+        if is_valid_filename(filename):
+            return filename
         return f"ImagePaste-{strftime('%y%m%d-%H%M%S')}.png"
 
     def __repr__(self) -> str:

--- a/imagepaste/clipboard/clipboard.py
+++ b/imagepaste/clipboard/clipboard.py
@@ -72,6 +72,29 @@ class Clipboard(ABC):
             Returns:
                 str: a string representing a filename.
             """
+            from time import strftime
+            from ..image import Image
+            from ..helper import ADDON_NAME
+
+            VARIABLES_TABLE = [
+                ("${addonName}", ADDON_NAME),
+                ("${yearLong}", strftime("%Y")),
+                ("${yearShort}", strftime("%y")),
+                ("${monthNumber}", strftime("%m")),
+                ("${monthNameLong}", strftime("%B")),
+                ("${monthNameShort}", strftime("%b")),
+                ("${day}", strftime("%d")),
+                ("${weekdayNumber}", strftime("%w")),
+                ("${weekdayNameLong}", strftime("%A")),
+                ("${weekdayNameShort}", strftime("%a")),
+                ("${hour24}", strftime("%H")),
+                ("${hour12}", strftime("%I")),
+                ("${minute}", strftime("%M")),
+                ("${second}", strftime("%S")),
+                ("${index}", str(len(Image.pasted_images) + 1)),
+            ]
+            for pattern_key, pattern_value in VARIABLES_TABLE:
+                pattern = pattern.replace(pattern_key, pattern_value)
             return pattern
 
         from time import strftime
@@ -82,7 +105,7 @@ class Clipboard(ABC):
         filename = populate_filename(preferences.image_filename_pattern) + ".png"
         if is_valid_filename(filename):
             return filename
-        return f"ImagePaste-{strftime('%y%m%d-%H%M%S')}.png"
+        return strftime("ImagePaste-%y%m%d-%H%M%S.png")
 
     def __repr__(self) -> str:
         """Representation of the object.

--- a/imagepaste/clipboard/darwin/darwin.py
+++ b/imagepaste/clipboard/darwin/darwin.py
@@ -46,7 +46,7 @@ class DarwinClipboard(Clipboard):
         # Save an image if it is in the clipboard
         contents = pb.get_contents(type=pasteboard.TIFF)
         if contents is not None:
-            filename = cls.get_timestamp_filename()
+            filename = cls.get_filename()
             filepath = join(save_directory, filename)
             commands = [
                 "set pastedImage to "

--- a/imagepaste/clipboard/linux/linux.py
+++ b/imagepaste/clipboard/linux/linux.py
@@ -50,7 +50,7 @@ class LinuxClipboard(Clipboard):
 
         # If there is an image in clipboard, save the image and send its path
         if XclipTarget.IMAGE.value in process.stdout:
-            filename = cls.get_timestamp_filename()
+            filename = cls.get_filename()
             filepath = join(save_directory, filename)
             process = Process.execute(
                 cls.get_xclip_args(XclipTarget.IMAGE.value), outpath=filepath

--- a/imagepaste/clipboard/windows/windows.py
+++ b/imagepaste/clipboard/windows/windows.py
@@ -37,7 +37,7 @@ class WindowsClipboard(Clipboard):
 
         image_script = (
             "$image = Get-Clipboard -Format Image\n"
-            f'if ($image) {{ $image.Save("{filepath}"); Write-Output 0 }}'
+            f"if ($image) {{ $image.Save('{filepath}'); Write-Output 0 }}"
         )
         process = Process.execute(cls.get_powershell_args(image_script), split=False)
         if process.stderr:

--- a/imagepaste/clipboard/windows/windows.py
+++ b/imagepaste/clipboard/windows/windows.py
@@ -32,7 +32,7 @@ class WindowsClipboard(Clipboard):
         """
         from os.path import join
 
-        filename = cls.get_timestamp_filename()
+        filename = cls.get_filename()
         filepath = join(save_directory, filename)
 
         image_script = (

--- a/imagepaste/helper.py
+++ b/imagepaste/helper.py
@@ -57,6 +57,23 @@ def is_valid_filename(filename: str) -> bool:
         bool: True if the filename is valid, False otherwise.
     """
 
+    def is_general_valid_filename(filename: str) -> bool:
+        """Check if the filename is valid.
+
+        Args:
+            filename (str): a string representing the file name.
+
+        Returns:
+            bool: True if the filename is valid, False otherwise.
+        """
+        if not filename:
+            return False
+        if len(filename) > 255:
+            return False
+        if filename in (".", ".."):
+            return False
+        return True
+
     def is_windows_valid_filename(filename: str) -> bool:
         """Check if the filename is valid on Windows.
 
@@ -66,7 +83,46 @@ def is_valid_filename(filename: str) -> bool:
         Returns:
             bool: True if the filename is valid on Windows, False otherwise.
         """
-        pass
+        # Check if the filename does not end with a dot or a space
+        if filename[-1] in (".", " "):
+            return False
+        # Check if the filename is a reserved name
+        windows_reserved_filenames = (
+            "CON",
+            "PRN",
+            "AUX",
+            "NUL",
+            "COM1",
+            "COM2",
+            "COM3",
+            "COM4",
+            "COM5",
+            "COM6",
+            "COM7",
+            "COM8",
+            "COM9",
+            "LPT1",
+            "LPT2",
+            "LPT3",
+            "LPT4",
+            "LPT5",
+            "LPT6",
+            "LPT7",
+            "LPT8",
+            "LPT9",
+        )
+        if filename.upper() in windows_reserved_filenames:
+            return False
+        # Check if the filename contains any invalid characters
+        windows_invalid_characters = ("/", "\\", ":", "*", "?", '"', "<", ">", "|")
+        for character in windows_invalid_characters:
+            if character in filename:
+                return False
+        # Check if the filename contains any unprintable characters
+        for index in range(31):
+            if chr(index) in filename:
+                return False
+        return True
 
     def is_linux_valid_filename(filename: str) -> bool:
         """Check if the filename is valid on Linux.
@@ -77,7 +133,12 @@ def is_valid_filename(filename: str) -> bool:
         Returns:
             bool: True if the filename is valid on Linux, False otherwise.
         """
-        pass
+        # The "\" character is valid in Linux but Blender does not support it
+        invalid_characters = ["/", "\\"]
+        for invalid_character in invalid_characters:
+            if invalid_character in filename:
+                return False
+        return True
 
     def is_darwin_valid_filename(filename: str) -> bool:
         """Check if the filename is valid on macOS.
@@ -88,10 +149,12 @@ def is_valid_filename(filename: str) -> bool:
         Returns:
             bool: True if the filename is valid on macOS, False otherwise.
         """
-        pass
+        return is_linux_valid_filename(filename)
 
     import sys
 
+    if not is_general_valid_filename(filename):
+        return False
     if sys.platform == "win32":
         return is_windows_valid_filename(filename)
     elif sys.platform == "linux":

--- a/imagepaste/helper.py
+++ b/imagepaste/helper.py
@@ -162,3 +162,48 @@ def is_valid_filename(filename: str) -> bool:
     elif sys.platform == "darwin":
         return is_darwin_valid_filename(filename)
     return False
+
+
+def populate_filename(filename_pattern: str) -> str:
+    """Populate a filename with a pattern.
+
+    Args:
+        pattern (str): a string representing a pattern.
+
+    Returns:
+        str: a string representing a filename.
+    """
+    import re
+    from time import strftime
+    from .image import Image
+    from .helper import ADDON_NAME
+
+    image_index = str(len(Image.pasted_images) + 1)
+    # Replace normal variables
+    VARIABLES_TABLE = [
+        ("${addonName}", ADDON_NAME),
+        ("${yearLong}", strftime("%Y")),
+        ("${yearShort}", strftime("%y")),
+        ("${monthNumber}", strftime("%m")),
+        ("${monthNameLong}", strftime("%B")),
+        ("${monthNameShort}", strftime("%b")),
+        ("${day}", strftime("%d")),
+        ("${weekdayNumber}", strftime("%w")),
+        ("${weekdayNameLong}", strftime("%A")),
+        ("${weekdayNameShort}", strftime("%a")),
+        ("${hour24}", strftime("%H")),
+        ("${hour12}", strftime("%I")),
+        ("${minute}", strftime("%M")),
+        ("${second}", strftime("%S")),
+        ("${index}", image_index),
+    ]
+    for pattern_key, pattern_value in VARIABLES_TABLE:
+        filename_pattern = filename_pattern.replace(pattern_key, pattern_value)
+    # Replace dynamic variables ${index:N}
+    # Produce an N-digits-with-zeros-padded number
+    filename_pattern = re.sub(
+        r"\${index\:(\d+)}",
+        lambda match: image_index.zfill(int(match.group(1))),
+        filename_pattern,
+    )
+    return filename_pattern

--- a/imagepaste/helper.py
+++ b/imagepaste/helper.py
@@ -45,3 +45,57 @@ def get_save_directory() -> str:
     if not exists(subdirectory_path):
         makedirs(subdirectory_path)
     return subdirectory_path
+
+
+def is_valid_filename(filename: str) -> bool:
+    """Check if the filename is valid.
+
+    Args:
+        filename (str): a string representing the file name.
+
+    Returns:
+        bool: True if the filename is valid, False otherwise.
+    """
+
+    def is_windows_valid_filename(filename: str) -> bool:
+        """Check if the filename is valid on Windows.
+
+        Args:
+            filename (str): a string representing a filename.
+
+        Returns:
+            bool: True if the filename is valid on Windows, False otherwise.
+        """
+        pass
+
+    def is_linux_valid_filename(filename: str) -> bool:
+        """Check if the filename is valid on Linux.
+
+        Args:
+            filename (str): a string representing a filename.
+
+        Returns:
+            bool: True if the filename is valid on Linux, False otherwise.
+        """
+        pass
+
+    def is_darwin_valid_filename(filename: str) -> bool:
+        """Check if the filename is valid on macOS.
+
+        Args:
+            filename (str): a string representing a filename.
+
+        Returns:
+            bool: True if the filename is valid on macOS, False otherwise.
+        """
+        pass
+
+    import sys
+
+    if sys.platform == "win32":
+        return is_windows_valid_filename(filename)
+    elif sys.platform == "linux":
+        return is_linux_valid_filename(filename)
+    elif sys.platform == "darwin":
+        return is_darwin_valid_filename(filename)
+    return False

--- a/imagepaste/helper.py
+++ b/imagepaste/helper.py
@@ -178,7 +178,7 @@ def populate_filename(filename_pattern: str) -> str:
     from .image import Image
     from .helper import ADDON_NAME
 
-    image_index = str(len(Image.pasted_images) + 1)
+    image_index = str(Image.image_index + 1)
     # Replace normal variables
     VARIABLES_TABLE = [
         ("${addonName}", ADDON_NAME),

--- a/imagepaste/image.py
+++ b/imagepaste/image.py
@@ -2,6 +2,7 @@ class Image:
     """A class to represent an image file."""
 
     pasted_images = {}
+    image_index = 0
 
     def __init__(self, filepath: str, pasted: bool = False) -> None:
         """Constructor for the Image class.
@@ -14,6 +15,7 @@ class Image:
         self.filepath = filepath
         if pasted:
             Image.pasted_images[self.filepath] = self
+            Image.image_index += 1
 
     @property
     def filepath(self) -> str:

--- a/imagepaste/operators.py
+++ b/imagepaste/operators.py
@@ -198,10 +198,10 @@ class IMAGEPASTE_OT_view3d_paste_reference(bpy.types.Operator):
         )
 
 
-class IMAGEPASTE_OT_move_to_saved_directory(bpy.types.Operator):
+class IMAGEPASTE_OT_move_to_save_directory(bpy.types.Operator):
     """Move images to a target directory"""
 
-    bl_idname = "imagepaste.move_to_saved_directory"
+    bl_idname = "imagepaste.move_to_save_directory"
     bl_label = "Move to Target Directory"
     bl_options = {"UNDO_GROUPED"}
 
@@ -209,8 +209,8 @@ class IMAGEPASTE_OT_move_to_saved_directory(bpy.types.Operator):
         from .helper import get_save_directory
 
         super().__init__()
-        self.saved_directory = get_save_directory()
-        self.orphaned_images = self.get_orphaned_images(self.saved_directory)
+        self.save_directory = get_save_directory()
+        self.orphaned_images = self.get_orphaned_images(self.save_directory)
 
     def execute(self, _context):
         from .image import Image
@@ -221,7 +221,7 @@ class IMAGEPASTE_OT_move_to_saved_directory(bpy.types.Operator):
         # Change the paths the images refers to with the new one
         for orphaned_image in self.orphaned_images:
             old_filepath = self.get_abspath(orphaned_image.filepath)
-            self.change_image_directory(orphaned_image, self.saved_directory)
+            self.change_image_directory(orphaned_image, self.save_directory)
             new_filepath = self.get_abspath(orphaned_image.filepath)
             # Also change in the dictionary
             if old_filepath in pasted_images:
@@ -269,11 +269,11 @@ class IMAGEPASTE_OT_move_to_saved_directory(bpy.types.Operator):
         """
         return [self.get_abspath(image.filepath) for image in images]
 
-    def get_orphaned_images(self, saved_directory: str) -> list[bpy.types.Image]:
+    def get_orphaned_images(self, save_directory: str) -> list[bpy.types.Image]:
         """Get images that are not in the target directory.
 
         Args:
-            saved_directory (str): The target directory.
+            save_directory (str): The target directory.
 
         Returns:
             list[bpy.types.Image]: A list of orphaned images.
@@ -296,7 +296,7 @@ class IMAGEPASTE_OT_move_to_saved_directory(bpy.types.Operator):
             if not image.filepath:
                 continue
             filepath = self.get_abspath(image.filepath)
-            if dirname(filepath) == saved_directory:
+            if dirname(filepath) == save_directory:
                 continue
             if preferences.image_type_to_move == "all_images":
                 orphaned_images.append(image)
@@ -307,18 +307,18 @@ class IMAGEPASTE_OT_move_to_saved_directory(bpy.types.Operator):
         return orphaned_images
 
     def change_image_directory(
-        self, orphaned_image: bpy.types.Image, saved_directory: str
+        self, orphaned_image: bpy.types.Image, save_directory: str
     ) -> None:
         """Change the directory of an orphaned image.
 
         Args:
             orphaned_image (bpy.types.Image): An orphaned image.
-            saved_directory (str): The target directory.
+            save_directory (str): The target directory.
         """
         from os.path import join
         from shutil import copyfile
 
-        new_filepath = join(saved_directory, bpy.path.basename(orphaned_image.filepath))
+        new_filepath = join(save_directory, bpy.path.basename(orphaned_image.filepath))
         copyfile(bpy.path.abspath(orphaned_image.filepath), new_filepath)
         orphaned_image.filepath = new_filepath
         orphaned_image.reload()
@@ -331,7 +331,7 @@ classes = (
     IMAGEPASTE_OT_shadereditor_paste,
     IMAGEPASTE_OT_view3d_paste_plane,
     IMAGEPASTE_OT_view3d_paste_reference,
-    IMAGEPASTE_OT_move_to_saved_directory,
+    IMAGEPASTE_OT_move_to_save_directory,
 )
 
 

--- a/imagepaste/operators.py
+++ b/imagepaste/operators.py
@@ -24,13 +24,15 @@ class IMAGEPASTE_OT_imageeditor_copy(bpy.types.Operator):
     def execute(self, context):
         from os.path import join
         from .helper import get_save_directory
+        from .helper import get_addon_preferences
 
         active_image = context.area.spaces.active.image
         # If active image is render result, save it first
         if active_image.filepath != "":
             image_path = active_image.filepath
         else:
-            image_path = join(get_save_directory(), active_image.name + ".png")
+            image_extension = get_addon_preferences().image_extension
+            image_path = join(get_save_directory(), active_image.name + image_extension)
             bpy.ops.image.save_as(save_as_render=True, copy=True, filepath=image_path)
         # Report and log the result
         clipboard = Clipboard.pull(image_path)

--- a/imagepaste/preferences.py
+++ b/imagepaste/preferences.py
@@ -58,6 +58,11 @@ class IMAGEPASTE_AddonPreferences(bpy.types.AddonPreferences):
         ),
         subtype="FILE_NAME",
     )
+    image_extension: bpy.props.StringProperty(
+        name="Image extension",
+        description="A file extension for pasted images",
+        get=lambda _: ".png",
+    )
     image_type_to_move: bpy.props.EnumProperty(
         name="Image type to move",
         description="Which type of image will be moved",
@@ -143,8 +148,13 @@ class IMAGEPASTE_AddonPreferences(bpy.types.AddonPreferences):
         column_1.label(text="Image file name")
         # Second column
         column_2 = split.column().row(align=True)
-        column_2.alert = not is_valid_filename(self.image_filename_pattern + ".png")
+        column_2.alert = not is_valid_filename(
+            self.image_filename_pattern + self.image_extension
+        )
         column_2.prop(self, "image_filename_pattern", text="")
+        column_2_sub = column_2.column(align=True)
+        column_2_sub.alignment = "RIGHT"
+        column_2_sub.prop(self, "image_extension", text="")
 
         # New box
         box = layout.box().column()

--- a/imagepaste/preferences.py
+++ b/imagepaste/preferences.py
@@ -48,10 +48,15 @@ class IMAGEPASTE_AddonPreferences(bpy.types.AddonPreferences):
         name="Image file name",
         description=(
             "A name for pasted images\n"
-            "%y: Year, %m: Month, %d: Day\n"
-            "%H: Hour, %M: Minute, %S: Second"
+            "Go to the Documentation to read more about the variables\n"
+            "Warning: Images can be overwritten if they have the same name"
         ),
-        default="ImagePaste-%y%m%d-%H%M%S",
+        default=(
+            "${addonName}"
+            "-${yearShort}${monthNumber}${day}"
+            "-${hour24}${minute}${second}"
+        ),
+        subtype="FILE_NAME",
     )
     image_type_to_move: bpy.props.EnumProperty(
         name="Image type to move",
@@ -138,8 +143,8 @@ class IMAGEPASTE_AddonPreferences(bpy.types.AddonPreferences):
         column_1.label(text="Image file name")
         # Second column
         column_2 = split.column().row(align=True)
+        column_2.alert = not is_valid_filename(self.image_filename_pattern + ".png")
         column_2.prop(self, "image_filename_pattern", text="")
-        column_2.alert = is_valid_filename(self.image_filename_pattern)
 
         # New box
         box = layout.box().column()

--- a/imagepaste/preferences.py
+++ b/imagepaste/preferences.py
@@ -233,8 +233,8 @@ def view3d_paste_reference_imageaddmenu_draw(self, _context):
 
 
 @bpy.app.handlers.persistent
-def move_to_saved_directory_handler(self, _context):
-    bpy.ops.imagepaste.move_to_saved_directory("INVOKE_DEFAULT")
+def move_to_save_directory_handler(self, _context):
+    bpy.ops.imagepaste.move_to_save_directory("INVOKE_DEFAULT")
 
 
 addon_keymaps = []
@@ -249,7 +249,7 @@ def register():
     bpy.types.NODE_MT_context_menu.append(shadereditor_paste_contextmenu_draw)
     bpy.types.VIEW3D_MT_image_add.append(view3d_paste_plane_imageaddmenu_draw)
     bpy.types.VIEW3D_MT_image_add.append(view3d_paste_reference_imageaddmenu_draw)
-    bpy.app.handlers.save_post.append(move_to_saved_directory_handler)
+    bpy.app.handlers.save_post.append(move_to_save_directory_handler)
 
     kc = bpy.context.window_manager.keyconfigs.addon
 
@@ -321,7 +321,7 @@ def unregister():
         km.keymap_items.remove(kmi)
     addon_keymaps.clear()
 
-    bpy.app.handlers.save_post.remove(move_to_saved_directory_handler)
+    bpy.app.handlers.save_post.remove(move_to_save_directory_handler)
     bpy.types.VIEW3D_MT_image_add.remove(view3d_paste_reference_imageaddmenu_draw)
     bpy.types.VIEW3D_MT_image_add.remove(view3d_paste_plane_imageaddmenu_draw)
     bpy.types.NODE_MT_context_menu.remove(shadereditor_paste_contextmenu_draw)

--- a/imagepaste/preferences.py
+++ b/imagepaste/preferences.py
@@ -81,6 +81,7 @@ class IMAGEPASTE_AddonPreferences(bpy.types.AddonPreferences):
 
     def draw(self, _context):
         from .helper import is_valid_filename
+        from .helper import populate_filename
 
         split_ratio = 0.3
         layout = self.layout
@@ -148,9 +149,8 @@ class IMAGEPASTE_AddonPreferences(bpy.types.AddonPreferences):
         column_1.label(text="Image file name")
         # Second column
         column_2 = split.column().row(align=True)
-        column_2.alert = not is_valid_filename(
-            self.image_filename_pattern + self.image_extension
-        )
+        filename = populate_filename(self.image_filename_pattern) + self.image_extension
+        column_2.alert = not is_valid_filename(filename)
         column_2.prop(self, "image_filename_pattern", text="")
         column_2_sub = column_2.column(align=True)
         column_2_sub.alignment = "RIGHT"

--- a/imagepaste/preferences.py
+++ b/imagepaste/preferences.py
@@ -44,6 +44,15 @@ class IMAGEPASTE_AddonPreferences(bpy.types.AddonPreferences):
         description="A name for subdirectory",
         default="ImagePaste",
     )
+    image_filename_pattern: bpy.props.StringProperty(
+        name="Image file name",
+        description=(
+            "A name for pasted images\n"
+            "%y: Year, %m: Month, %d: Day\n"
+            "%H: Hour, %M: Minute, %S: Second"
+        ),
+        default="ImagePaste-%y%m%d-%H%M%S",
+    )
     image_type_to_move: bpy.props.EnumProperty(
         name="Image type to move",
         description="Which type of image will be moved",
@@ -61,6 +70,8 @@ class IMAGEPASTE_AddonPreferences(bpy.types.AddonPreferences):
     )
 
     def draw(self, _context):
+        from .helper import is_valid_filename
+
         split_ratio = 0.3
         layout = self.layout
 
@@ -113,6 +124,22 @@ class IMAGEPASTE_AddonPreferences(bpy.types.AddonPreferences):
         column_2.prop(self, "is_use_subdirectory", text="")
         column_2_sub = column_2.column()
         column_2_sub.prop(self, "subdirectory_name", text="")
+
+        # New box
+        box = layout.box().column()
+        box.label(text="Custom image file name")
+
+        # New property
+        prop = box.row(align=True)
+        split = prop.split(factor=split_ratio)
+        # First column
+        column_1 = split.column()
+        column_1.alignment = "RIGHT"
+        column_1.label(text="Image file name")
+        # Second column
+        column_2 = split.column().row(align=True)
+        column_2.prop(self, "image_filename_pattern", text="")
+        column_2.alert = is_valid_filename(self.image_filename_pattern)
 
         # New box
         box = layout.box().column()


### PR DESCRIPTION
## Proposed changes

This pull request adds a feature that allows the user to customize the filename of the pasted image with the help of some predefined variables:

| Variable              | Description                                          | Example                        |
| --------------------- | ---------------------------------------------------- | ------------------------------ |
| `${addonName}`        | Name of the add-on                                   | _ImagePaste_                   |
| `${yearLong}`         | Year with the century                                | 2021, 2022, …                  |
| `${yearShort}`        | Year without the century                             | 21, 22, …                      |
| `${monthNumber}`      | Month as a zero-padded decimal number                | 01, 02, …, 12                  |
| `${monthNameLong}`    | Full month name                                      | January, February, …, December |
| `${monthNameShort}`   | Abbreviated month name                               | Jan, Feb, …, Dec               |
| `${day}`              | Day of the month as a zero-padded decimal number     | 01, 02, …, 31                  |
| `${weekdayNumber}`    | Weekday as a decimal number                          | 0, 1, …, 6                     |
| `${weekdayNameLong}`  | Full weekday name                                    | Sunday, Monday, …, Saturday    |
| `${weekdayNameShort}` | Abbreviated weekday name                             | Sun, Mon, …, Sat               |
| `${hour24}`           | Hour (24-hour clock) as a zero-padded decimal number | 00, 01, …, 23                  |
| `${hour12}`           | Hour (12-hour clock) as a zero-padded decimal number | 01, 02, …, 12                  |
| `${minute}`           | Minute as a zero-padded decimal number               | 00, 01, …, 59                  |
| `${second}`           | Second as a zero-padded decimal number               | 00, 01, …, 59                  |
| `${index}`            | Order of the image                                   | 1, 2, …                        |
| `${index:N}`          | N-digits image order number with zero padding        | `${index:3}` gives 01, 02, …   |

The user will enter the name in a new section in the add-on preferences. There are some filename restrictions depending on each operating system. If the input filenames are not valid, the field will warn them by turning red and the new image name will fall back to default name `${addonName}-${yearShort}${monthNumber}${day}-${hour24}${minute}${second}`.

## Screenshot
- New add-on preferences section:
![custom-filename](https://user-images.githubusercontent.com/60842560/129077715-9e97e014-37d5-439d-928e-87f530ca57d9.png)
- Alert when the filename is invalid:
![custom-filename-failed](https://user-images.githubusercontent.com/60842560/129077718-16f8e030-7dd5-4728-8d75-30804016346e.png)

## Further comments

- Fix the _PowerShell_ script doesn't take raw strings (cfc2847bc6e0755c4a5db5d56b97d9b9de27a4b5).
- Fix the `pasted images` dictionary still keeps undone images after saving (from #17) (5888fc241e75d71b3cc805f58f049315e344495d).
