### PR TITLE
Fix non English filepath error in windows

### DIFF
--- a/imagepaste/clipboard/windows/windows.py
+++ b/imagepaste/clipboard/windows/windows.py
@@ -103,7 +103,8 @@ class WindowsClipboard(Clipboard):
             "$OutputEncoding = "
             "[System.Console]::OutputEncoding = "
             "[System.Console]::InputEncoding = "
-            "[System.Text.Encoding]::UTF8\n" + script
+            "[System.Text.Encoding]::UTF8\n"
+            "$PSDefaultParameterValues['*:Encoding'] = 'utf8'\n" + script
         )
         args = POWERSHELL + ["& { " + script + " }"]
         return args

--- a/imagepaste/clipboard/windows/windows.py
+++ b/imagepaste/clipboard/windows/windows.py
@@ -99,5 +99,11 @@ class WindowsClipboard(Clipboard):
             "-WindowStyle",
             "Hidden",
         ]
+        script = (
+            "$OutputEncoding = "
+            "[System.Console]::OutputEncoding = "
+            "[System.Console]::InputEncoding = "
+            "[System.Text.Encoding]::UTF8\n" + script
+        )
         args = POWERSHELL + ["& { " + script + " }"]
         return args

--- a/imagepaste/process.py
+++ b/imagepaste/process.py
@@ -6,12 +6,8 @@ class Process:
 
     def __init__(self) -> None:
         """Initialize a Process instance."""
-
-        from locale import getdefaultlocale
-        encoding = getdefaultlocale()[1]
-
         self.parameters = {
-            "encoding": encoding,
+            "encoding": "utf-8",
             "text": True,
         }
         self.stdout = None

--- a/imagepaste/process.py
+++ b/imagepaste/process.py
@@ -6,8 +6,12 @@ class Process:
 
     def __init__(self) -> None:
         """Initialize a Process instance."""
+
+        from locale import getdefaultlocale
+        encoding = getdefaultlocale()[1]
+
         self.parameters = {
-            "encoding": "utf-8",
+            "encoding": encoding,
             "text": True,
         }
         self.stdout = None


### PR DESCRIPTION
add suppport for different encoding system(For Example,'GBK') in Windows using local.getdefaultlocale()
Now can import image like `测试图像.png` and not raise Index Error again.

<!-- Thanks for sending a pull request! It's really great that you make it here. Please make sure you follow our contribution guidelines. -->

## Proposed changes
<!-- Describe your changes here to communicate to the maintainers (using a list of changes might be a great idea). If your pull request is connected to an open issue, add a line in your PR's description that says `Fixes #123`, where `#123` is the number of the issue you're fixing. -->


## Screenshots/Screencasts
<!-- It'd be even better if you showed us how your changes work. You can fill out the table below or do as you see fit. -->

https://user-images.githubusercontent.com/64118610/135513404-26a2c9a0-c2bd-4df4-a3ca-6fd98dcb11d1.mp4


## Further comments
<!-- Is there anything else you didn't tell us (the story about how the idea came to you, why you chose this method, or anything you still cannot overcome…)? -->

<!-- 💗 Thank you! -->
