### PR TITLE
Support both 4.2 and older versions and fix an exception

### DIFF
--- a/imagepaste/operators.py
+++ b/imagepaste/operators.py
@@ -14,6 +14,20 @@ else:
 import bpy
 
 
+# override the api
+def bpy_ops_import_image_to_plane(*args, **kwargs):
+    if bpy.app.version[0] < 4 or (bpy.app.version[0] == 4 and bpy.app.version[1] < 2):
+        return bpy.ops.import_image.to_plane(*args, **kwargs)
+    # the latest api
+    return bpy.ops.image.import_as_mesh_planes(*args, **kwargs)
+
+def bpy_ops_object_load_reference_image(*args, **kwargs):
+    if bpy.app.version[0] < 4 or (bpy.app.version[0] == 4 and bpy.app.version[1] < 2):
+        return bpy.ops.object.load_reference_image(*args, **kwargs)
+    # the latest api
+    return bpy.ops.object.empty_image_add(*args, **kwargs)
+
+
 class IMAGEPASTE_OT_imageeditor_copy(bpy.types.Operator):
     """Copy image to the clipboard"""
 
@@ -158,7 +172,7 @@ class IMAGEPASTE_OT_view3d_paste_plane(bpy.types.Operator):
         if clipboard.report.type != "INFO":
             return {"CANCELLED"}
         for image in clipboard.images:
-            bpy.ops.import_image.to_plane(files=[{"name": image.filepath}])
+            bpy_ops_import_image_to_plane(files=[{"name": image.filepath}])
         return {"FINISHED"}
 
     @classmethod
@@ -185,7 +199,7 @@ class IMAGEPASTE_OT_view3d_paste_reference(bpy.types.Operator):
         if clipboard.report.type != "INFO":
             return {"CANCELLED"}
         for image in clipboard.images:
-            bpy.ops.object.load_reference_image(filepath=image.filepath)
+            bpy_ops_object_load_reference_image(filepath=image.filepath)
         return {"FINISHED"}
 
     @classmethod

--- a/imagepaste/preferences.py
+++ b/imagepaste/preferences.py
@@ -259,7 +259,8 @@ def view3d_paste_reference_imageaddmenu_draw(self, _context):
 @bpy.app.handlers.persistent
 def move_to_save_directory_handler(_self, _context):
     """Handler to move the images to the save directory after the file is saved."""
-    bpy.ops.imagepaste.move_to_save_directory("INVOKE_DEFAULT")
+    if bpy.ops.imagepaste.move_to_save_directory.poll():
+        bpy.ops.imagepaste.move_to_save_directory("INVOKE_DEFAULT")
 
 
 addon_keymaps = []


### PR DESCRIPTION
## Proposed changes

* Support both 4.2 and older versions
* Fix an exception when clicking `File -> Defaults -> Save Startup File`


## Screenshots/Screencasts

Below is the exception in Blender 3.5 and 4.2:

![imagepaste](https://github.com/user-attachments/assets/27f6d240-38ac-4a71-a882-bf69bfa1fb28)
